### PR TITLE
Update AboutPage.java

### DIFF
--- a/library/src/main/java/mehdi/sakout/aboutpage/AboutPage.java
+++ b/library/src/main/java/mehdi/sakout/aboutpage/AboutPage.java
@@ -362,8 +362,15 @@ public class AboutPage {
             iconView.setLayoutParams(iconParams);
             int iconPadding = mContext.getResources().getDimensionPixelSize(R.dimen.about_icon_padding);
             iconView.setPadding(iconPadding,0,iconPadding,0);
-            iconView.setImageResource(element.getIcon());
-
+            //iconView.setImageResource(element.getIcon());
+            
+            if (Build.VERSION.SDK_INT < 21) {
+                Drawable drawable = VectorDrawableCompat.create(iconView.getResources(), element.getIcon(), iconView.getContext().getTheme());
+                iconView.setImageDrawable(drawable);
+            } else {
+                iconView.setImageResource(element.getIcon());
+            }
+            
             Drawable wrappedDrawable = DrawableCompat.wrap(iconView.getDrawable());
             wrappedDrawable = wrappedDrawable.mutate();
 


### PR DESCRIPTION
Project About Page for your Android App, Android does not work with less than 21 because of the vector, if used AppCompat 23.3.0 or higher. You need to replace
 line 366 iconView.setImageResource (element.getIcon ());
on
if (Build.VERSION.SDK_INT <21) 
{
Drawable drawable = VectorDrawableCompat.create (. iconView.getResources (), element.getIcon (), iconView.getContext () getTheme ()); iconView.setImageDrawable (drawable); 
} Else {
iconView.setImageResource (element.getIcon ()); 
}
and then everything works