### PR TITLE
Allowing HTML tags in the description field

### DIFF
--- a/library/src/main/java/mehdi/sakout/aboutpage/AboutPage.java
+++ b/library/src/main/java/mehdi/sakout/aboutpage/AboutPage.java
@@ -15,6 +15,8 @@ import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.widget.TextViewCompat;
+import android.text.Html;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -499,7 +501,13 @@ public class AboutPage {
         }
 
         if (!TextUtils.isEmpty(mDescription)) {
-            description.setText(mDescription);
+            Spanned text;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                text = Html.fromHtml(mDescription,Html.FROM_HTML_MODE_LEGACY);
+            } else {
+                text = Html.fromHtml(mDescription);
+            }
+            description.setText(text);
         }
 
         description.setGravity(Gravity.CENTER);

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="about_page_description" translatable="false" >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vehicula ligula tortor, in pellentesque dui congue ac. Vestibulum lacinia urna magna, quis cursus ante iaculis nec. Nunc ut ligula sit amet odio ultrices euismod vel vel purus. Sed lacus mauris, aliquam et placerat id</string>
+    <string name="about_page_description" translatable="false" ><b>Lorem</b> ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vehicula ligula tortor, in pellentesque dui congue ac. Vestibulum lacinia urna magna, quis cursus ante iaculis nec. Nunc ut ligula sit amet odio ultrices euismod vel vel purus. Sed lacus mauris, aliquam et placerat id</string>
 
     <string name="about_contact_us">Contact us</string>
     <string name="about_instagram">Follow us on Instagram</string>


### PR DESCRIPTION
This PR allows the description field to include HTML tags like \<b> and \<i> by making use of the [Html](https://developer.android.com/reference/android/text/Html.html) class.