### PR TITLE
Migrate Gradle snippet away from deprecated config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ View aboutPage = new AboutPage(this)
 Available on Jcenter, Maven and JitPack
 
 ```groovy
-compile 'com.github.medyo:android-about-page:1.2.5'
+implementation 'com.github.medyo:android-about-page:1.2.5'
 ```
 
 


### PR DESCRIPTION
The `compile` configuration has been deprecated in favor of `implementation`

https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations