### PR TITLE
Improved Dark Mode of About Us page

### DIFF
--- a/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
+++ b/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
@@ -20,13 +20,19 @@ public class MainActivity extends AppCompatActivity {
 
         View aboutPage = new AboutPage(this)
                 .isRTL(false)
-                .enableDarkMode(true)
+                .enableDarkMode(false)
                 .setImage(R.drawable.dummy_image)
                 .addItem(new Element().setTitle("Version 6.2"))
                 .addItem(adsElement)
                 .addGroup("Connect with us")
                 .addEmail("elmehdi.sakout@gmail.com")
                 .addWebsite("https://mehdisakout.com/")
+                .addFacebook("the.medy")
+                .addTwitter("medyo80")
+                .addYoutube("UCdPQtdWIsg7_pi4mrRu46vA")
+                .addPlayStore("com.ideashower.readitlater.pro")
+                .addInstagram("medyo80")
+                .addGitHub("medyo")
                 .addItem(getCopyRightsElement())
                 .create();
 

--- a/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
+++ b/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
@@ -20,19 +20,13 @@ public class MainActivity extends AppCompatActivity {
 
         View aboutPage = new AboutPage(this)
                 .isRTL(false)
-                .enableDarkMode(false)
+                .enableDarkMode(true)
                 .setImage(R.drawable.dummy_image)
                 .addItem(new Element().setTitle("Version 6.2"))
                 .addItem(adsElement)
                 .addGroup("Connect with us")
                 .addEmail("elmehdi.sakout@gmail.com")
                 .addWebsite("https://mehdisakout.com/")
-                .addFacebook("the.medy")
-                .addTwitter("medyo80")
-                .addYoutube("UCdPQtdWIsg7_pi4mrRu46vA")
-                .addPlayStore("com.ideashower.readitlater.pro")
-                .addInstagram("medyo80")
-                .addGitHub("medyo")
                 .addItem(getCopyRightsElement())
                 .create();
 

--- a/library/src/main/res/layout/about_page.xml
+++ b/library/src/main/res/layout/about_page.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
     <LinearLayout
+        android:id="@+id/sub_wrapper"
+        style="@style/about_About.wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:id="@+id/sub_wrapper"
-        style="@style/about_About.wrapper">
+        android:orientation="vertical">
 
         <LinearLayout style="@style/about_sub_wrapper">
 
@@ -21,7 +22,9 @@
                 style="@style/about_description" />
         </LinearLayout>
 
-        <View android:id="@+id/description_separator" style="@style/about_separator" />
+        <View
+            android:id="@+id/description_separator"
+            style="@style/about_separator" />
 
         <LinearLayout
             android:id="@+id/about_providers"

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,7 +4,6 @@
     <style name="about_About" />
 
     <style name="about_About.wrapper">
-        <item name="android:gravity">center</item>
         <item name="android:background">@color/about_background_color</item>
     </style>
 
@@ -39,7 +38,6 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:background">@color/about_separator_color</item>
         <item name="android:padding">0dp</item>
-        <item name="android:layout_weight">1</item>
         <item name="android:layout_marginTop">0dp</item>
         <item name="android:layout_marginBottom">0dp</item>
     </style>


### PR DESCRIPTION
### Problem : 
If we add **less number of Elements** to our about page, then the hight of **ScrollView will shrink to the wrap the content**, which looks odd because the while colored background will show in the bottom after the end of ScorllView, to fix this issue ScrollView has a property called **_fillViewport_**.

 _( **_fillViewport_** allows scrollView to extend its height equals to the full height of the device screen's height in the cases when the child of the scroll view has less height. )_

> I am personally using your library in my college project. While using dark mode I saw this issue, so I thought about fixing it.


**Before screenshot :** 

![before_vv](https://user-images.githubusercontent.com/41951699/90338803-d751a100-e009-11ea-8aee-002c5925c881.jpg)

### Fixes :

- Added  `android:fillViewport="true"`  property to the ScrollView of `about_page.xml`.

- Removed  	`<item name="android:layout_weight">1</item>-->`  property from the `<style name="about_separator">` in the Style resource for the page separaor file (`about_page_separator.xml`) 

- Removed the gravity property  `<item name="android:gravity">center</item>`  in the  `<style name="about_About.wrapper">` Style resource,  because it was creating an empty void space between the `description` and `about_providers`.

**After screenshot :**

![after_vv](https://user-images.githubusercontent.com/41951699/90338832-0536e580-e00a-11ea-9d6b-c79823475cb0.jpg)

Rudra,
Feel free to leave your comments.

