### PR TITLE
Add style attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,28 @@ styling attributes to create a dedicated style for `AboutPage`. If the
 dependents choose not to specify an explicit style, the library falls back to
 sensible defaults.
 
+First, declare an `AboutPage` style in your `styles.xml`.
+
 ```xml
-<style name="Widget.AboutPage" parent="about_About">
-  <item name="aboutBackground">@color/background_color</item>
-  <item name="aboutDescriptionTextAppearance">@style/descriptionTextAppearance</item>
-  <item name="aboutSeparatorColor">@color/separator_color</item>
-  <item name="aboutElementTextAppearance">@style/elementTextAppearance</item>
-  <item name="aboutElementIconTint">@color/item_icon_color</item>
-  <item name="aboutGroupTextAppearance">@style/groupTextAppearance</item>
+<!-- Define a global style for AboutPage in your 'styles.xml' -->
+<style name="Widget.App.AboutPage" parent="about_About">
+  <item name="aboutBackground">#ffffff</item>
+  <item name="aboutElementIconTint">#333333</item>
+  <item name="aboutSeparatorColor">#999999</item>
+  <item name="aboutDescriptionTextAppearance">@style/TextAppearance.App.AboutPage.Description</item>
+
+  <!-- similarly, you can also apply the following text appearances -->
+  <item name="aboutElementTextAppearance">@style/about_elementTextAppearance.Dark</item>
+  <item name="aboutGroupTextAppearance">@style/about_groupTextAppearance</item>
 </style>
+
+<style name="TextAppearance.App.AboutPage.Description" parent="about_descriptionTextAppearance.Dark">
+  <item name="android:textStyle">bold|italic</item>
+</style>
+
 ```
 
-To apply the style globally, assign its reference to `aboutStyle` attribute in
+To apply this style globally, assign its reference to `aboutStyle` attribute in
 your app theme.
 
 ```xml
@@ -128,7 +138,8 @@ your app theme.
 </style>
 ```
 
-Or explicitly pass the style resource to the `AboutPage` constructor.
+Or explicitly pass the style resource to the `AboutPage` constructor to apply it
+on selective `AboutPage` instances.
 
 ```java
 AboutPage aboutPage = new AboutPage(context, R.style.Widget_AboutPage);
@@ -140,7 +151,9 @@ We recommend that the dependents use
 [`AppCompatDelegate.setDefaultNightMode()`](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setDefaultNightMode(int))
 to force enable/disable the night mode across their apps. If the dependents are
 unable to use the recommended approach, they can use the `AboutPage(Context,
-boolean)` constructor to specify the desired mode.
+boolean)` constructor to specify the desired mode. The dependents must note that
+by using this constructor, the `AboutPage` will use its default styles, ignoring
+any explicitly specified style.
 
 ```java
 AboutPage aboutPage = AboutPage(context, true); // force enable dark mode.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This library allows to generate beautiful About Pages with less effort, it's ful
 ```java
 View aboutPage = new AboutPage(this)
   .isRTL(false)
-  .enableDarkMode(false)
   .setCustomFont(String) // or Typeface
   .setImage(R.drawable.dummy_image)
   .addItem(versionElement)
@@ -102,11 +101,50 @@ addItem(versionElement)
 ```
 snippet by [nrhoffmann](https://github.com/nrhoffmann)
 
-### 6. Optional dark mode
+### 7. Styling
+
+The library supports day-night modes. The dependents may use the following
+styling attributes to create a dedicated style for `AboutPage`. If the
+dependents choose not to specify an explicit style, the library falls back to
+sensible defaults.
+
+```xml
+<style name="Widget.AboutPage" parent="about_About">
+  <item name="aboutBackground">@color/background_color</item>
+  <item name="aboutDescriptionTextAppearance">@style/descriptionTextAppearance</item>
+  <item name="aboutSeparatorColor">@color/separator_color</item>
+  <item name="aboutElementTextAppearance">@style/elementTextAppearance</item>
+  <item name="aboutElementIconTint">@color/item_icon_color</item>
+  <item name="aboutGroupTextAppearance">@style/groupTextAppearance</item>
+</style>
+```
+
+To apply the style globally, assign its reference to `aboutStyle` attribute in
+your app theme.
+
+```xml
+<style name="Theme.App" parent="Theme.AppCompat">
+  <item name="aboutStyle">@style/Widget.AboutPage</item>
+</style>
+```
+
+Or explicitly pass the style resource to the `AboutPage` constructor.
+
 ```java
-View aboutPage = new AboutPage(this)
-  .enableDarkMode(false) // if true, the dark mode is forced otherwise the default light one
-  .create()
+AboutPage aboutPage = new AboutPage(context, R.style.Widget_AboutPage);
+```
+
+### 8. Force Night/Day mode
+
+We recommend that the dependents use
+[`AppCompatDelegate.setDefaultNightMode()`](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setDefaultNightMode(int))
+to force enable/disable the night mode across their apps. If the dependents are
+unable to use the recommended approach, they can use the `AboutPage(Context,
+boolean)` constructor to specify the desired mode.
+
+```java
+AboutPage aboutPage = AboutPage(context, true); // force enable dark mode.
+AboutPage aboutPage = AboutPage(context, false); // force enable bright mode.
 ```
 
 ## Sample Project

--- a/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
+++ b/app/src/main/java/mehdi/sakout/aboutpage/sample/MainActivity.java
@@ -20,7 +20,6 @@ public class MainActivity extends AppCompatActivity {
 
         View aboutPage = new AboutPage(this)
                 .isRTL(false)
-                .enableDarkMode(false)
                 .setImage(R.drawable.dummy_image)
                 .addItem(new Element().setTitle("Version 6.2"))
                 .addItem(adsElement)

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#263238</color>
     <color name="colorPrimaryDark">#212121</color>
     <color name="colorAccent">#50bcb6</color>
+    <color name="colorDescriptionText">#50bcb6</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#ef4056</color>
     <color name="colorPrimaryDark">#ac2435</color>
     <color name="colorAccent">#50bcb6</color>
+    <color name="colorDescriptionText">#ef4056</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,16 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="aboutStyle">@style/Widget.App.AboutPage</item>
+    </style>
+
+    <style name="Widget.App.AboutPage" parent="about_About">
+        <item name="aboutDescriptionTextAppearance">@style/descriptionTextAppearance</item>
+    </style>
+
+    <style name="descriptionTextAppearance" parent="about_descriptionTextAppearance">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/colorDescriptionText</item>
     </style>
 
 </resources>

--- a/library/src/main/java/mehdi/sakout/aboutpage/AboutPageUtils.java
+++ b/library/src/main/java/mehdi/sakout/aboutpage/AboutPageUtils.java
@@ -3,8 +3,14 @@ package mehdi.sakout.aboutpage;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.os.Build;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.util.TypedValue;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.util.List;
 
@@ -25,16 +31,40 @@ class AboutPageUtils {
         return installed;
     }
 
-    static int getThemeAccentColor(Context context) {
-        int colorAttr;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            colorAttr = android.R.attr.colorAccent;
-        } else {
-            //Get colorAccent defined for AppCompat
-            colorAttr = context.getResources().getIdentifier("colorAccent", "attr", context.getPackageName());
+    @ColorInt
+    static int resolveColorAttr(@NonNull Context context, @AttrRes int attr) {
+        final TypedValue outValue = resolveAttr(context, attr);
+        if (outValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && outValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+            return outValue.data;
         }
-        TypedValue outValue = new TypedValue();
-        context.getTheme().resolveAttribute(colorAttr, outValue, true);
-        return outValue.data;
+
+        return ContextCompat.getColor(context, outValue.resourceId);
+    }
+
+    static int resolveResIdAttr(@NonNull Context context, @AttrRes int attr, int defaultValue) {
+        try {
+            return resolveAttr(context, attr).resourceId;
+        } catch (Resources.NotFoundException e) {
+            return defaultValue;
+        }
+    }
+
+    @NonNull
+    private static TypedValue resolveAttr(@NonNull Context context, @AttrRes int attr) {
+        final TypedValue outValue = new TypedValue();
+        if (!context.getTheme().resolveAttribute(attr, outValue, true)) {
+            throw new Resources.NotFoundException("'" + context.getResources().getResourceName(attr) + "' is not set.");
+        }
+
+        if (outValue.type == TypedValue.TYPE_ATTRIBUTE) {
+            return resolveAttr(context, outValue.data);
+        }
+
+        return outValue;
+    }
+
+    static boolean isNightModeEnabled(@NonNull Context context) {
+        final int nightMode = context.getResources().getConfiguration().uiMode;
+        return (nightMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
     }
 }

--- a/library/src/main/res/layout/about_page.xml
+++ b/library/src/main/res/layout/about_page.xml
@@ -19,6 +19,7 @@
 
             <TextView
                 android:id="@+id/description"
+                android:text="@string/about_page_description"
                 style="@style/about_description" />
         </LinearLayout>
 

--- a/library/src/main/res/values-night/styles.xml
+++ b/library/src/main/res/values-night/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="about_About" parent="about_AboutBase_Dark" />
+</resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="aboutStyle" format="reference" />
+    <attr name="aboutBackground" format="reference|color" />
+    <attr name="aboutDescriptionTextAppearance" format="reference" />
+    <attr name="aboutSeparatorColor" format="color" />
+    <attr name="aboutElementTextAppearance" format="reference" />
+    <attr name="aboutElementIconTint" format="color" />
+    <attr name="aboutGroupTextAppearance" format="reference" />
+</resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="about_text_color">#595959</color>
 
     <!-- Dark Mode -->
+    <color name="about_item_icon_dark_color">?colorAccent</color>
     <color name="about_background_dark_color">#303030</color>
     <color name="about_separator_dark_color">#494949</color>
 

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="about_About" />
+    <style name="about_About" parent="about_AboutBase_Light" />
 
-    <style name="about_About.wrapper">
-        <item name="android:background">@color/about_background_color</item>
+    <style name="about_AboutBase_Light">
+        <item name="aboutBackground">@color/about_background_color</item>
+        <item name="aboutDescriptionTextAppearance">@style/about_descriptionTextAppearance</item>
+        <item name="aboutSeparatorColor">@color/about_separator_color</item>
+        <item name="aboutElementTextAppearance">@style/about_elementTextAppearance</item>
+        <item name="aboutElementIconTint">@color/about_item_icon_color</item>
+        <item name="aboutGroupTextAppearance">@style/about_groupTextAppearance</item>
+    </style>
+
+    <style name="about_AboutBase_Dark">
+        <item name="aboutBackground">@color/about_background_dark_color</item>
+        <item name="aboutDescriptionTextAppearance">@style/about_descriptionTextAppearance.Dark</item>
+        <item name="aboutSeparatorColor">@color/about_separator_dark_color</item>
+        <item name="aboutElementTextAppearance">@style/about_elementTextAppearance.Dark</item>
+        <item name="aboutElementIconTint">@color/about_item_icon_dark_color</item>
+        <item name="aboutGroupTextAppearance">@style/about_groupTextAppearance.Dark</item>
+    </style>
+
+    <style name="about_About.wrapper" parent="">
+        <item name="android:background">?attr/aboutBackground</item>
     </style>
 
     <style name="about_sub_wrapper">
@@ -23,20 +41,28 @@
         <item name="android:layout_marginTop">20dp</item>
     </style>
 
-    <style name="about_description" parent="@android:style/TextAppearance">
+    <style name="about_description" parent="">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:text">@string/about_page_description</item>
-        <item name="android:lineSpacingExtra">8dp</item>
         <item name="android:layout_marginBottom">20dp</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textAppearance">?attr/aboutDescriptionTextAppearance</item>
+    </style>
+
+    <style name="about_descriptionTextAppearance" parent="@android:style/TextAppearance">
+        <item name="android:lineSpacingExtra">8dp</item>
         <item name="android:textColor">@color/about_description_text_color</item>
         <item name="android:textSize">@dimen/about_description_text_size</item>
+    </style>
+
+    <style name="about_descriptionTextAppearance.Dark">
+        <item name="android:textColor">@color/about_description_dark_text_color</item>
     </style>
 
     <style name="about_separator">
         <item name="android:layout_height">@dimen/about_separator_height</item>
         <item name="android:layout_width">match_parent</item>
-        <item name="android:background">@color/about_separator_color</item>
+        <item name="android:background">?attr/aboutSeparatorColor</item>
         <item name="android:padding">0dp</item>
         <item name="android:layout_marginTop">0dp</item>
         <item name="android:layout_marginBottom">0dp</item>
@@ -47,8 +73,16 @@
         <item name="android:textSize">@dimen/about_item_text_size</item>
     </style>
 
+    <style name="about_elementTextAppearance.Dark">
+        <item name="android:textColor">@color/about_text_dark_color</item>
+    </style>
+
     <style name="about_groupTextAppearance" parent="@android:style/TextAppearance">
         <item name="android:textColor">@color/about_item_text_color</item>
         <item name="android:textSize">@dimen/about_group_item_text_size</item>
+    </style>
+
+    <style name="about_groupTextAppearance.Dark" parent="@android:style/TextAppearance">
+        <item name="android:textColor">@color/about_item_dark_text_color</item>
     </style>
 </resources>


### PR DESCRIPTION
## Context

Styling `AboutPage` in current versions is frowned upon. Currently, we explicitly override colors in my app to override the style.

## Changes

- Add the following styling attributes to change colors and text appearances.
  1. `aboutBackground`
  2. `aboutSeparatorColor`
  3. `aboutDescriptionTextAppearance`
  4. `aboutGroupTextAppearance`
  5. `aboutElementTextAppearance`
  6. `aboutElementIconTint`
- Add `aboutStyle` attribute to globally define styling attributes for AboutPage in XML
- Replace `enableDarkMode()` with `AboutPage(Context, boolean)` constructor. I tried to keep it, but it was breaking the flow
- Add `AboutPage(Context, int)` to override global `aboutStyle`

As a result of these changes, the library can also handle day/night mode changes via `AppCompatDelegate`.

Please let me know your thoughts!